### PR TITLE
bump hash-for-dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "broccoli-plugin": "^1.0.0",
     "copy-dereference": "^1.0.0",
     "debug": "^2.2.0",
-    "hash-for-dep": "0.0.3",
+    "hash-for-dep": "^1.0.0",
     "md5-hex": "^1.0.2",
     "mkdirp": "^0.5.1",
     "promise-map-series": "^0.2.1",


### PR DESCRIPTION
I think this got reverted in the merge.