### PR TITLE
[fixes #34] ensure the cached file has the target output name.

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,7 @@ Filter.prototype.processAndCacheFile =
     function processAndCacheFile(srcDir, destDir, relativePath) {
   var self = this;
   var cacheEntry = this._cache.get(relativePath);
+  var outputRelativeFile = self.getDestFilePath(relativePath);
 
   if (cacheEntry) {
     var hashResult = hash(srcDir, cacheEntry.inputFile);
@@ -139,7 +140,7 @@ Filter.prototype.processAndCacheFile =
     if (cacheEntry.hash.hash === hashResult.hash) {
       this._debug('cache hit: %s', relativePath);
 
-      return symlinkOrCopyFromCache(cacheEntry, destDir, relativePath);
+      return symlinkOrCopyFromCache(cacheEntry, destDir, outputRelativeFile);
     } else {
       this._debug('cache miss: %s \n  - previous: %o \n  - next:     %o ', relativePath, cacheEntry.hash.key, hashResult.key);
     }
@@ -167,8 +168,8 @@ Filter.prototype.processAndCacheFile =
     var entry = {
       hash: hash(srcDir, relativePath),
       inputFile: relativePath,
-      outputFile: destDir + '/' + self.getDestFilePath(relativePath),
-      cacheFile: self.cachePath + '/' + relativePath
+      outputFile: destDir + '/' + outputRelativeFile,
+      cacheFile: self.cachePath + '/' + outputRelativeFile
     };
 
     if (fs.existsSync(entry.cacheFile)) {

--- a/test/test.js
+++ b/test/test.js
@@ -347,10 +347,12 @@ describe('Filter', function() {
   describe('processFile', function() {
     beforeEach(function() {
       sinon.spy(fs, 'mkdirSync');
+      sinon.spy(fs, 'writeFileSync');
     });
 
     afterEach(function() {
       fs.mkdirSync.restore();
+      fs.writeFileSync.restore();
     });
 
     it('should not effect the current cwd', function() {
@@ -366,6 +368,10 @@ describe('Filter', function() {
       }).then(function(results) {
         expect(fs.mkdirSync.calledWith(path.join(process.cwd(), 'a'), 493)).to.eql(false);
         expect(fs.mkdirSync.calledWith(path.join(process.cwd(), 'a', 'bar'), 493)).to.eql(false);
+        expect(fs.writeFileSync.calledWith(path.join(process.cwd(), 'a', 'foo.js'), "Nicest dogs in need of homes")).to.eql(false);
+        return results.builder();
+      }).then(function() {
+        expect(fs.writeFileSync.calledWith(path.join(process.cwd(), 'a', 'foo.js'), "Nicest dogs in need of homes")).to.eql(false);
       });
     });
   });


### PR DESCRIPTION
Mostly we do JS -> JS transforms, but HBS -> JS only worked on initial build because of this.