### PR TITLE
Add an environment variable for cache location.

### DIFF
--- a/lib/strategies/persistent.js
+++ b/lib/strategies/persistent.js
@@ -11,6 +11,7 @@ module.exports = {
     }
 
     this._cache = new AsyncDiskCache(ctx.constructor._persistentCacheKey, {
+      location: process.env['BROCCOLI_PERSISTENT_FILTER_CACHE_ROOT'],
       compression: 'deflate'
     });
   },


### PR DESCRIPTION
Defaults to the `async-disk-cache` default value.

Fixes #24.

---

Can be used with Travis cache with the following `.travis.yml` config:

```
cache:
  directories:
      - node_modules
      - $HOME/persistent-filter-cache

env:
- BROCCOLI_PERSISTENT_FILTER_CACHE_ROOT=$HOME/persistent-filter-cache
```