### PR TITLE
Add Debug logging around persistent

### DIFF
--- a/lib/strategies/persistent.js
+++ b/lib/strategies/persistent.js
@@ -26,8 +26,10 @@ module.exports = {
 
     return cache.get(key).then(function(entry) {
       if (entry.isCached) {
+        ctx._debug('persistent cache hit: %s', relativePath);
         return entry.value;
       } else {
+        ctx._debug('persistent cache prime: %s', relativePath);
         var string = Promise.resolve(ctx.processString(contents, relativePath));
 
         return string.then(function(string) {


### PR DESCRIPTION
Prior to this commit we would only have logging around the in memory
hits and primes. This adds logging to the persistent cache.