### PR TITLE
add try/catch around fs.unlinkSync in Filter.prototype.build to protect against ENOENT, no such file or directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,13 @@ Filter.prototype.build = function build() {
   var paths = walkSync(srcDir);
 
   this._cache.deleteExcept(paths).forEach(function(key) {
-    fs.unlinkSync(this.cachePath + '/' + key);
+    try {
+      fs.unlinkSync(this.cachePath + '/' + key);
+    } catch (e) {
+      if(e.code !== 'ENOENT') {
+        throw e;
+      }
+    }
   }, this);
 
   return mapSeries(paths, function rebuildEntry(relativePath) {


### PR DESCRIPTION
related to 

https://github.com/stefanpenner/broccoli-persistent-filter/issues/29
https://github.com/ember-cli/ember-cli/issues/4782#issuecomment-136495069