### PR TITLE
Add postProcess method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,15 @@ class Filter {
    * Abstract method `processString`: must be implemented on subclasses of
    * Filter.
    *
-   * The return value is written as the contents of the output file
+   * The resolved return value can either be an object or a string.
+   *
+   * An object can be used to cache additional meta-data that is not part of the
+   * final output. When an object is returned, the `.output` property of that
+   * object is used as the resulting file contents.
+   *
+   * When a string is returned it is used as the file contents.
    */
-  abstract processString(contents: string, relativePath: string): string;
+  abstract processString(contents: string, relativePath: string): {string | object };
 
   /**
    * Virtual method `getDestFilePath`: determine whether the source file should
@@ -39,6 +45,23 @@ class Filter {
    * extension in the list is replaced with the `targetExtension` option's value.
    */
   virtual getDestFilePath(relativePath: string): string;
+
+  /**
+   * Method `postProcess`: may be implemented on subclasses of
+   * Filter.
+   *
+   * This method can be used in subclasses to do processing on the results of
+   * each files `processString` method.
+   *
+   * A common scenario for this is linting plugins, where on initial build users
+   * expect to get console warnings for lint errors, but we do not want to re-lint
+   * each file on every boot (since most of them will be able to be served from the
+   * cache).
+   *
+   * The `.output` property of the return value is used as the emitted file contents.
+   */
+  postProcess(results: object, relativePath: string): object
+
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -244,3 +244,7 @@ Filter.prototype.processString = function(/* contents, relativePath */) {
       'When subclassing broccoli-persistent-filter you must implement the ' +
       '`processString()` method.');
 };
+
+Filter.prototype.postProcess = function(result /*, relativePath */) {
+  return result;
+};

--- a/lib/strategies/default.js
+++ b/lib/strategies/default.js
@@ -1,9 +1,32 @@
 'use strict';
 
+var Promise = require('rsvp').Promise;
+
 module.exports = {
   init: function() {},
 
   processString: function(ctx, contents, relativePath) {
-    return ctx.processString(contents, relativePath);
+    var string = new Promise(function(resolve) {
+      resolve(ctx.processString(contents, relativePath));
+    });
+
+    return string.then(function(value) {
+      var normalizedValue = value;
+
+      if (typeof value === 'string') {
+        normalizedValue = { output: value };
+      }
+
+      return new Promise(function(resolve) {
+        resolve(ctx.postProcess(normalizedValue, relativePath));
+      })
+        .then(function(result) {
+          if (result === undefined) {
+            throw new Error('You must return an object from `Filter.prototype.postProcess`.');
+          }
+
+          return result.output;
+        });
+    });
   }
 };

--- a/lib/strategies/persistent.js
+++ b/lib/strategies/persistent.js
@@ -25,21 +25,51 @@ module.exports = {
   processString: function(ctx, contents, relativePath) {
     var key = ctx.cacheKeyProcessString(contents, relativePath);
     var cache = this._cache;
+    var string;
 
     return cache.get(key).then(function(entry) {
       if (entry.isCached) {
         ctx._debug('persistent cache hit: %s', relativePath);
-        return entry.value;
+
+        string = Promise.resolve(entry.value)
+          .then(function(value) {
+            return JSON.parse(value);
+          });
       } else {
         ctx._debug('persistent cache prime: %s', relativePath);
-        var string = Promise.resolve(ctx.processString(contents, relativePath));
+        string = new Promise(function(resolve) {
+          resolve(ctx.processString(contents, relativePath));
+        })
+          .then(function(result) {
+            if (typeof result === 'string') {
+              return { output: result };
+            } else {
+              return result;
+            }
+          })
+          .then(function(value) {
+            var stringValue = JSON.stringify(value);
 
-        return string.then(function(string) {
-          return cache.set(key, string).then(function() {
-            return string;
+            return cache.set(key, stringValue).then(function() {
+              return value;
+            });
           });
-        });
+
       }
+
+      return string
+        .then(function(object) {
+          return new Promise(function(resolve) {
+            resolve(ctx.postProcess(object, relativePath));
+          })
+            .then(function(result) {
+              if (result === undefined) {
+                throw new Error('You must return an object from `Filter.prototype.postProcess`.');
+              }
+
+              return result.output;
+            });
+        });
     });
   }
 };


### PR DESCRIPTION
This allows plugins that want to take advantage of persistent filter's
performance characteristics, but still need to have some code ran for
initial build persistent cache hits (since `processString` isn't called
again on initial build when cache is warmed).

The motivating use-case is for linters. Users of linting tools generally
expect to see all linting output in the console for every initial build.
Prior to this change, that was not possible.

With this change, it would be possible for a linting tool to embed data
in its emitted output so that it can have enough information to generate
these `console.log` statements by simply reading the cached value
provided to the hook.

This changes the in-cache representation to always be JSON with an
`.output` property containing the string output. This allows or
returning any `JSON.stringy`able object from `processString` and receive
that object in `postProcess` for both cache hits and misses.