### PR TITLE
add counters and verbose vs non-verbose logging modes

### DIFF
--- a/lib/strategies/persistent.js
+++ b/lib/strategies/persistent.js
@@ -29,13 +29,15 @@ module.exports = {
 
     return cache.get(key).then(function(entry) {
       if (entry.isCached) {
-        ctx._debug('persistent cache hit: %s', relativePath);
+        ctx._counters.hit++;
+        ctx._verboseDebug('persistent cache hit: %s', relativePath);
 
         string = Promise.resolve(entry.value).then(function(value) {
           return JSON.parse(value);
         });
       } else {
-        ctx._debug('persistent cache prime: %s', relativePath);
+        ctx._counters.prime++;
+        ctx._verboseDebug('persistent cache prime: %s', relativePath);
         string = new Promise(function(resolve) {
           resolve(ctx.processString(contents, relativePath));
         }).then(function(result) {


### PR DESCRIPTION
Standard debug logging: `DEBUG=broccoli-persistent-filter*`

![screen shot 2016-06-30 at 8 19 00 am](https://cloud.githubusercontent.com/assets/1377/16493716/52b13d3e-3e9b-11e6-83f2-f5a50821a40a.png)

Verbose debug logging: `DEBUG_VERBOSE=1 DEBUG=broccoli-persistent-filter*`
![screen shot 2016-06-30 at 8 20 10 am](https://cloud.githubusercontent.com/assets/1377/16493774/93cb69b6-3e9b-11e6-8c13-a1b5c226e7b7.png)

