### PR TITLE
Remove leftover debugger

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var defaultProccessor = require('./lib/strategies/default');
 var hashForDep = require('hash-for-dep');
 var BlankObject = require('blank-object');
 var FSTree = require('fs-tree-diff');
-var IS_VERBOSE = !!process.env.DEBUG_VERBOSE
+var IS_VERBOSE = !!process.env.DEBUG_VERBOSE;
 
 module.exports = Filter;
 
@@ -115,7 +115,7 @@ Filter.prototype.build = function() {
     this._debug('build complete: %s, in: %dms', '' + this, Date.now() - start);
     this.debugLogCounters();
     this.resetCounters();
-  }.bind(this))
+  }.bind(this));
 };
 
 Filter.prototype.debugLogCounters = function() {

--- a/index.js
+++ b/index.js
@@ -113,7 +113,6 @@ Filter.prototype.build = function() {
     }
   }, this).then(function() {
     this._debug('build complete: %s, in: %dms', '' + this, Date.now() - start);
-    debugger;
     this.debugLogCounters();
     this.resetCounters();
   }.bind(this))

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "istanbul": "^0.4.2",
     "minimatch": "^3.0.0",
     "mocha": "^2.2.5",
+    "mocha-jshint": "^2.3.1",
     "rimraf": "^2.4.2",
     "sinon": "^1.15.3",
     "sinon-chai": "^2.8.0"

--- a/test/jshint.spec.js
+++ b/test/jshint.spec.js
@@ -1,0 +1,7 @@
+require('mocha-jshint')({
+  paths: [
+    './lib',
+    './index.js',
+    './test/test.js'
+  ]
+});

--- a/test/test.js
+++ b/test/test.js
@@ -681,7 +681,7 @@ describe('Filter', function() {
         return awk;
       });
 
-      return builder('dir', { persist: true }).then(function(results) {
+      return builder('dir', { persist: true }).then(function(/*results*/) {
         // do nothing, just kicked off to warm the persistent cache
       }).then(function() {
         return builder('dir', { persist: true });


### PR DESCRIPTION
I assume that the addition of this debugger was an accident, and it's making my node debugging of ember-cli stuff a marginally less fantastic experience.

In the spirit of adding a failing test w/ the fix, I've included a mocha JSHint plugin.