### PR TITLE
Allow create and change operations to complete asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ class Filter {
 * `name`, `annotation`: Same as
   [broccoli-plugin](https://github.com/broccolijs/broccoli-plugin#new-plugininputnodes-options);
   see there.
+* `concurrency`: Used with `async: true`. The number of operations that can be
+  run concurrently. This overrides the value set with `JOBS=n` environment variable.
+  (default: the number of detected CPU cores - 1, with a min of 1)
 
 All options except `name` and `annotation` can also be set on the prototype
 instead of being passed into the constructor.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ class Filter {
 * `outputEncoding`: The character encoding used for writing output files after
   processing (default: `'utf8'`). For binary files, pass `null` and return a
   `Buffer` object from `processString`.
+* `async`: Whether the `create` and `change` file operations are allowed to
+  complete asynchronously (true|false, default: false)
 * `name`, `annotation`: Same as
   [broccoli-plugin](https://github.com/broccolijs/broccoli-plugin#new-plugininputnodes-options);
   see there.

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function Filter(inputTree, options) {
   this._destFilePathCache = Object.create(null);
   this._needsReset = false;
 
-  this.concurrency = Number(process.env.JOBS) || require('os').cpus().length;
+  this.concurrency = (options && options.concurrency) || Number(process.env.JOBS) || Math.max(require('os').cpus().length - 1, 1);
 }
 
 function nanosecondsSince(time) {
@@ -167,9 +167,9 @@ Filter.prototype.build = function() {
               instrumentation.unlink++;
               return fs.unlinkSync(outputPath);
             } case 'change': {
-              instrumentation.change++;
               // wrap this in a function so it doesn't actually run yet, and can be throttled
               var changeOperation = function() {
+                instrumentation.change++;
                 return plugin._handleFile(relativePath, srcDir, destDir, entry, outputFilePath, true, instrumentation);
               };
               if (plugin.async) {
@@ -178,9 +178,9 @@ Filter.prototype.build = function() {
               }
               return changeOperation();
             } case 'create': {
-              instrumentation.create++;
               // wrap this in a function so it doesn't actually run yet, and can be throttled
               var createOperation = function() {
+                instrumentation.create++;
                 return plugin._handleFile(relativePath, srcDir, destDir, entry, outputFilePath, false, instrumentation);
               };
               if (plugin.async) {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var defaultProccessor = require('./lib/strategies/default');
 var hashForDep = require('hash-for-dep');
 var FSTree = require('fs-tree-diff');
 var heimdall = require('heimdalljs');
+var allSettled = require('rsvp').allSettled;
 
 
 function ApplyPatchesSchema() {
@@ -188,9 +189,9 @@ Filter.prototype.build = function() {
 
       return result;
     }));
-  }).then(function(result) {
-    return Promise.all(pendingWork).then(function() {
-      return result;
+  }).then(function(completedResult) {
+    return allSettled(pendingWork).then(function() {
+      return Promise.all(completedResult.concat(pendingWork));
     });
   }).then(function(result) {
     plugin._needsReset = false;

--- a/index.js
+++ b/index.js
@@ -39,6 +39,8 @@ function DerivePatchesSchema() {
   this.entries = 0;
 }
 
+const worker = queue.async.asyncify((doWork) => doWork());
+
 module.exports = Filter;
 
 Filter.prototype = Object.create(Plugin.prototype);
@@ -192,10 +194,8 @@ Filter.prototype.build = function() {
           }
         });
         resolve(result);
-      }).then(() => {
-        const worker = queue.async.asyncify((doWork) => doWork());
-        return queue(worker, pendingWork, plugin.concurrency);
-      }).then((result) => {
+      }).then(() => queue(worker, pendingWork, plugin.concurrency)
+      ).then((result) => {
         plugin._logger.info('applyPatches', 'duration:', timeSince(prevTime), JSON.stringify(instrumentation));
         plugin._needsReset = false;
         return result;

--- a/index.js
+++ b/index.js
@@ -189,11 +189,11 @@ Filter.prototype.build = function() {
 
       return result;
     }));
-  }).then(function(completedResult) {
-    return allSettled(pendingWork).then(function() {
+  }).then((completedResult) => {
+    return allSettled(pendingWork).then(() => {
       return Promise.all(completedResult.concat(pendingWork));
     });
-  }).then(function(result) {
+  }).then((result) => {
     plugin._needsReset = false;
     return result;
   });

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var FSTree = require('fs-tree-diff');
 var heimdall = require('heimdalljs');
 var queue = require('async-promise-queue');
 
+var concurrency = Number(process.env.JOBS) || require('os').cpus().length;
 
 function ApplyPatchesSchema() {
   this.mkdir = 0;
@@ -140,63 +141,61 @@ Filter.prototype.build = function() {
   // used with options.async = true to allow 'create' and 'change' operations to complete async
   var pendingWork = [];
 
-  return new Promise(function(resolve) {
-    resolve(heimdall.node('applyPatches', ApplyPatchesSchema, function(instrumentation) {
-      var prevTime = process.hrtime();
-      return new Promise(function(resolve) {
-        var result = mapSeries(patches, function(patch) {
-          var operation = patch[0];
-          var relativePath = patch[1];
-          var entry = patch[2];
-          var outputPath = destDir + '/' + (plugin.getDestFilePath(relativePath, entry) || relativePath);
-          var outputFilePath = outputPath;
+  return Promise.resolve(heimdall.node('applyPatches', ApplyPatchesSchema, function(instrumentation) {
+    var prevTime = process.hrtime();
+    return new Promise(function(resolve) {
+      var result = mapSeries(patches, function(patch) {
+        var operation = patch[0];
+        var relativePath = patch[1];
+        var entry = patch[2];
+        var outputPath = destDir + '/' + (plugin.getDestFilePath(relativePath, entry) || relativePath);
+        var outputFilePath = outputPath;
 
-          plugin._logger.debug('[operation:%s] %s', operation, relativePath);
+        plugin._logger.debug('[operation:%s] %s', operation, relativePath);
 
-          switch (operation) {
-            case 'mkdir': {
-              instrumentation.mkdir++;
-              return fs.mkdirSync(outputPath);
-            } case 'rmdir': {
-              instrumentation.rmdir++;
-              return fs.rmdirSync(outputPath);
-            } case 'unlink': {
-              instrumentation.unlink++;
-              return fs.unlinkSync(outputPath);
-            } case 'change': {
-              instrumentation.change++;
-              var changeOperation = plugin._handleFile(relativePath, srcDir, destDir, entry, outputFilePath, true, instrumentation);
-              // will be undefined if this.canProcessFile() == false
-              if (plugin.async && changeOperation !== undefined) {
-                pendingWork.push(changeOperation);
-                return;
-              }
-              return changeOperation;
-            } case 'create': {
-              instrumentation.create++;
-              var createOperation = plugin._handleFile(relativePath, srcDir, destDir, entry, outputFilePath, false, instrumentation);
-              // will be undefined if this.canProcessFile() == false
-              if (plugin.async && createOperation !== undefined) {
-                pendingWork.push(createOperation);
-                return;
-              }
-              return createOperation;
-            } default: {
-              instrumentation.other++;
+        switch (operation) {
+          case 'mkdir': {
+            instrumentation.mkdir++;
+            return fs.mkdirSync(outputPath);
+          } case 'rmdir': {
+            instrumentation.rmdir++;
+            return fs.rmdirSync(outputPath);
+          } case 'unlink': {
+            instrumentation.unlink++;
+            return fs.unlinkSync(outputPath);
+          } case 'change': {
+            instrumentation.change++;
+            var changeOperation = plugin._handleFile(relativePath, srcDir, destDir, entry, outputFilePath, true, instrumentation);
+            // will be undefined if this.canProcessFile() == false
+            if (plugin.async && changeOperation !== undefined) {
+              pendingWork.push(changeOperation);
+              return;
             }
+            return changeOperation;
+          } case 'create': {
+            instrumentation.create++;
+            var createOperation = plugin._handleFile(relativePath, srcDir, destDir, entry, outputFilePath, false, instrumentation);
+            // will be undefined if this.canProcessFile() == false
+            if (plugin.async && createOperation !== undefined) {
+              pendingWork.push(createOperation);
+              return;
+            }
+            return createOperation;
+          } default: {
+            instrumentation.other++;
           }
-        });
-        resolve(result);
-      }).then(() => {
-        const worker = queue.async.asyncify((promise) => promise);
-        return queue(worker, pendingWork, 4);
-      }).then((result) => {
-        plugin._logger.info('applyPatches', 'duration:', timeSince(prevTime), JSON.stringify(instrumentation));
-        plugin._needsReset = false;
-        return result;
+        }
       });
-    }));
-  });
+      resolve(result);
+    }).then(() => {
+      const worker = queue.async.asyncify((promise) => promise);
+      return queue(worker, pendingWork, concurrency);
+    }).then((result) => {
+      plugin._logger.info('applyPatches', 'duration:', timeSince(prevTime), JSON.stringify(instrumentation));
+      plugin._needsReset = false;
+      return result;
+    });
+  }));
 };
 
 Filter.prototype._handleFile = function(relativePath, srcDir, destDir, entry, outputPath, isChange, instrumentation) {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var FSTree = require('fs-tree-diff');
 var heimdall = require('heimdalljs');
 var queue = require('async-promise-queue');
 
+const concurrency = Number(process.env.JOBS) || require('os').cpus().length;
 
 function ApplyPatchesSchema() {
   this.mkdir = 0;
@@ -189,7 +190,7 @@ Filter.prototype.build = function() {
         resolve(result);
       }).then(() => {
         const worker = queue.async.asyncify((promise) => promise);
-        return queue(worker, pendingWork, 4);
+        return queue(worker, pendingWork, concurrency);
       }).then((result) => {
         plugin._logger.info('applyPatches', 'duration:', timeSince(prevTime), JSON.stringify(instrumentation));
         plugin._needsReset = false;

--- a/index.js
+++ b/index.js
@@ -18,8 +18,6 @@ var FSTree = require('fs-tree-diff');
 var heimdall = require('heimdalljs');
 var queue = require('async-promise-queue');
 
-const concurrency = Number(process.env.JOBS) || require('os').cpus().length;
-
 function ApplyPatchesSchema() {
   this.mkdir = 0;
   this.rmdir = 0;
@@ -88,6 +86,8 @@ function Filter(inputTree, options) {
   this._canProcessCache = Object.create(null);
   this._destFilePathCache = Object.create(null);
   this._needsReset = false;
+  
+  this.concurrency = Number(process.env.JOBS) || require('os').cpus().length;
 }
 
 function nanosecondsSince(time) {
@@ -190,7 +190,7 @@ Filter.prototype.build = function() {
         resolve(result);
       }).then(() => {
         const worker = queue.async.asyncify((promise) => promise);
-        return queue(worker, pendingWork, concurrency);
+        return queue(worker, pendingWork, plugin.concurrency);
       }).then((result) => {
         plugin._logger.info('applyPatches', 'duration:', timeSince(prevTime), JSON.stringify(instrumentation));
         plugin._needsReset = false;

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ var FSTree = require('fs-tree-diff');
 var heimdall = require('heimdalljs');
 var queue = require('async-promise-queue');
 
-var concurrency = Number(process.env.JOBS) || require('os').cpus().length;
 
 function ApplyPatchesSchema() {
   this.mkdir = 0;
@@ -141,61 +140,63 @@ Filter.prototype.build = function() {
   // used with options.async = true to allow 'create' and 'change' operations to complete async
   var pendingWork = [];
 
-  return Promise.resolve(heimdall.node('applyPatches', ApplyPatchesSchema, function(instrumentation) {
-    var prevTime = process.hrtime();
-    return new Promise(function(resolve) {
-      var result = mapSeries(patches, function(patch) {
-        var operation = patch[0];
-        var relativePath = patch[1];
-        var entry = patch[2];
-        var outputPath = destDir + '/' + (plugin.getDestFilePath(relativePath, entry) || relativePath);
-        var outputFilePath = outputPath;
+  return new Promise(function(resolve) {
+    resolve(heimdall.node('applyPatches', ApplyPatchesSchema, function(instrumentation) {
+      var prevTime = process.hrtime();
+      return new Promise(function(resolve) {
+        var result = mapSeries(patches, function(patch) {
+          var operation = patch[0];
+          var relativePath = patch[1];
+          var entry = patch[2];
+          var outputPath = destDir + '/' + (plugin.getDestFilePath(relativePath, entry) || relativePath);
+          var outputFilePath = outputPath;
 
-        plugin._logger.debug('[operation:%s] %s', operation, relativePath);
+          plugin._logger.debug('[operation:%s] %s', operation, relativePath);
 
-        switch (operation) {
-          case 'mkdir': {
-            instrumentation.mkdir++;
-            return fs.mkdirSync(outputPath);
-          } case 'rmdir': {
-            instrumentation.rmdir++;
-            return fs.rmdirSync(outputPath);
-          } case 'unlink': {
-            instrumentation.unlink++;
-            return fs.unlinkSync(outputPath);
-          } case 'change': {
-            instrumentation.change++;
-            var changeOperation = plugin._handleFile(relativePath, srcDir, destDir, entry, outputFilePath, true, instrumentation);
-            // will be undefined if this.canProcessFile() == false
-            if (plugin.async && changeOperation !== undefined) {
-              pendingWork.push(changeOperation);
-              return;
+          switch (operation) {
+            case 'mkdir': {
+              instrumentation.mkdir++;
+              return fs.mkdirSync(outputPath);
+            } case 'rmdir': {
+              instrumentation.rmdir++;
+              return fs.rmdirSync(outputPath);
+            } case 'unlink': {
+              instrumentation.unlink++;
+              return fs.unlinkSync(outputPath);
+            } case 'change': {
+              instrumentation.change++;
+              var changeOperation = plugin._handleFile(relativePath, srcDir, destDir, entry, outputFilePath, true, instrumentation);
+              // will be undefined if this.canProcessFile() == false
+              if (plugin.async && changeOperation !== undefined) {
+                pendingWork.push(changeOperation);
+                return;
+              }
+              return changeOperation;
+            } case 'create': {
+              instrumentation.create++;
+              var createOperation = plugin._handleFile(relativePath, srcDir, destDir, entry, outputFilePath, false, instrumentation);
+              // will be undefined if this.canProcessFile() == false
+              if (plugin.async && createOperation !== undefined) {
+                pendingWork.push(createOperation);
+                return;
+              }
+              return createOperation;
+            } default: {
+              instrumentation.other++;
             }
-            return changeOperation;
-          } case 'create': {
-            instrumentation.create++;
-            var createOperation = plugin._handleFile(relativePath, srcDir, destDir, entry, outputFilePath, false, instrumentation);
-            // will be undefined if this.canProcessFile() == false
-            if (plugin.async && createOperation !== undefined) {
-              pendingWork.push(createOperation);
-              return;
-            }
-            return createOperation;
-          } default: {
-            instrumentation.other++;
           }
-        }
+        });
+        resolve(result);
+      }).then(() => {
+        const worker = queue.async.asyncify((promise) => promise);
+        return queue(worker, pendingWork, 4);
+      }).then((result) => {
+        plugin._logger.info('applyPatches', 'duration:', timeSince(prevTime), JSON.stringify(instrumentation));
+        plugin._needsReset = false;
+        return result;
       });
-      resolve(result);
-    }).then(() => {
-      const worker = queue.async.asyncify((promise) => promise);
-      return queue(worker, pendingWork, concurrency);
-    }).then((result) => {
-      plugin._logger.info('applyPatches', 'duration:', timeSince(prevTime), JSON.stringify(instrumentation));
-      plugin._needsReset = false;
-      return result;
-    });
-  }));
+    }));
+  });
 };
 
 Filter.prototype._handleFile = function(relativePath, srcDir, destDir, entry, outputPath, isChange, instrumentation) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   ],
   "dependencies": {
     "async-disk-cache": "^1.2.1",
+    "async-promise-queue": "^1.0.2",
     "broccoli-plugin": "^1.0.0",
     "fs-tree-diff": "^0.5.2",
     "hash-for-dep": "^1.0.2",

--- a/test/helpers/replacer-async.js
+++ b/test/helpers/replacer-async.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var inherits = require('util').inherits;
+var path = require('path');
+var Promise = require('rsvp').Promise;
+var Filter = require('../../');
+var minimatch = require('minimatch');
+
+module.exports = ReplaceAsyncFilter;
+function ReplaceAsyncFilter(inputTree, _options) {
+  var options = _options || {};
+
+  if (!this) {
+    return new ReplaceAsyncFilter(inputTree, options);
+  }
+
+  Filter.call(this, inputTree, options);
+
+  this._glob = options.glob;
+  this._search = options.search;
+  this._replacement = options.replace;
+}
+
+inherits(ReplaceAsyncFilter, Filter);
+
+ReplaceAsyncFilter.prototype.getDestFilePath = function(relativePath) {
+  if (this._glob === undefined) {
+    return Filter.prototype.getDestFilePath.call(this, relativePath);
+  }
+  return minimatch(relativePath, this._glob) ? relativePath : null;
+};
+
+ReplaceAsyncFilter.prototype.processString = function(contents/*, relativePath*/) {
+  var result = contents.replace(this._search, this._replacement);
+  return new Promise(function(resolve) {
+    setTimeout(function() {
+      resolve(result);
+    }, 100);
+  });
+};
+
+ReplaceAsyncFilter.prototype.baseDir = function() {
+  return path.join(__dirname, '../../');
+};

--- a/test/helpers/replacer-async.js
+++ b/test/helpers/replacer-async.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var path = require('path');
-var Promise = require('rsvp').Promise;
-var Filter = require('../../');
-var minimatch = require('minimatch');
+const path = require('path');
+const Promise = require('rsvp').Promise;
+const Filter = require('../../');
+const minimatch = require('minimatch');
 
-class ReplaceAsyncFilter extends Filter {
+module.exports = class ReplaceAsyncFilter extends Filter {
   constructor(inputTree, _options) {
-    var options = _options || {};
+    let options = _options || {};
 
     super(inputTree, options);
 
@@ -24,9 +24,9 @@ class ReplaceAsyncFilter extends Filter {
   }
 
   processString(contents/*, relativePath*/) {
-    var result = contents.replace(this._search, this._replacement);
-    return new Promise(function(resolve) {
-      setTimeout(function() {
+    const result = contents.replace(this._search, this._replacement);
+    return new Promise((resolve) => {
+      setTimeout(() => {
         resolve(result);
       }, 50);
     });
@@ -35,6 +35,4 @@ class ReplaceAsyncFilter extends Filter {
   baseDir() {
     return path.join(__dirname, '../../');
   }
-}
-
-module.exports = ReplaceAsyncFilter;
+};

--- a/test/helpers/replacer-async.js
+++ b/test/helpers/replacer-async.js
@@ -1,44 +1,40 @@
 'use strict';
 
-var inherits = require('util').inherits;
 var path = require('path');
 var Promise = require('rsvp').Promise;
 var Filter = require('../../');
 var minimatch = require('minimatch');
 
-module.exports = ReplaceAsyncFilter;
-function ReplaceAsyncFilter(inputTree, _options) {
-  var options = _options || {};
+class ReplaceAsyncFilter extends Filter {
+  constructor(inputTree, _options) {
+    var options = _options || {};
 
-  if (!this) {
-    return new ReplaceAsyncFilter(inputTree, options);
+    super(inputTree, options);
+
+    this._glob = options.glob;
+    this._search = options.search;
+    this._replacement = options.replace;
   }
 
-  Filter.call(this, inputTree, options);
+  getDestFilePath(relativePath) {
+    if (this._glob === undefined) {
+      return Filter.prototype.getDestFilePath.call(this, relativePath);
+    }
+    return minimatch(relativePath, this._glob) ? relativePath : null;
+  }
 
-  this._glob = options.glob;
-  this._search = options.search;
-  this._replacement = options.replace;
+  processString(contents/*, relativePath*/) {
+    var result = contents.replace(this._search, this._replacement);
+    return new Promise(function(resolve) {
+      setTimeout(function() {
+        resolve(result);
+      }, 50);
+    });
+  }
+
+  baseDir() {
+    return path.join(__dirname, '../../');
+  }
 }
 
-inherits(ReplaceAsyncFilter, Filter);
-
-ReplaceAsyncFilter.prototype.getDestFilePath = function(relativePath) {
-  if (this._glob === undefined) {
-    return Filter.prototype.getDestFilePath.call(this, relativePath);
-  }
-  return minimatch(relativePath, this._glob) ? relativePath : null;
-};
-
-ReplaceAsyncFilter.prototype.processString = function(contents/*, relativePath*/) {
-  var result = contents.replace(this._search, this._replacement);
-  return new Promise(function(resolve) {
-    setTimeout(function() {
-      resolve(result);
-    }, 100);
-  });
-};
-
-ReplaceAsyncFilter.prototype.baseDir = function() {
-  return path.join(__dirname, '../../');
-};
+module.exports = ReplaceAsyncFilter;

--- a/test/helpers/rot13-async.js
+++ b/test/helpers/rot13-async.js
@@ -1,24 +1,22 @@
 'use strict';
 
-var Promise = require('rsvp').Promise;
-var Filter = require('../../');
+const Promise = require('rsvp').Promise;
+const Filter = require('../../');
 
 
-class Rot13Async extends Filter {
+module.exports = class Rot13Async extends Filter {
   constructor(inputTree, options) {
     super(inputTree, options);
   }
 
   processString(content) {
-    return new Promise(function(resolve) {
-      var result = content.replace(/[a-zA-Z]/g, function(c){
+    return new Promise((resolve) => {
+      const result = content.replace(/[a-zA-Z]/g, (c) => {
         return String.fromCharCode((c <= 'Z' ? 90 : 122) >= (c = c.charCodeAt(0) + 13) ? c : c - 26);
       });
-      setTimeout(function() {
+      setTimeout(() => {
         resolve(result);
       }, 50);
     });
   }
-}
-
-module.exports = Rot13Async;
+};

--- a/test/helpers/rot13-async.js
+++ b/test/helpers/rot13-async.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var inherits = require('util').inherits;
+var Promise = require('rsvp').Promise;
+var Filter = require('../../');
+
+module.exports = Rot13Async;
+
+function Rot13Async(inputTree, options) {
+  if (!this) {
+    return new Rot13Async(inputTree, options);
+  }
+  Filter.call(this, inputTree, options);
+}
+
+inherits(Rot13Async, Filter);
+
+Rot13Async.prototype.processString = function(content) {
+  return new Promise(function(resolve) {
+    var result = content.replace(/[a-zA-Z]/g, function(c){
+      return String.fromCharCode((c <= 'Z' ? 90 : 122) >= (c = c.charCodeAt(0) + 13) ? c : c - 26);
+    });
+    setTimeout(function() {
+      resolve(result);
+    }, 100);
+  });
+};

--- a/test/helpers/rot13-async.js
+++ b/test/helpers/rot13-async.js
@@ -1,27 +1,24 @@
 'use strict';
 
-var inherits = require('util').inherits;
 var Promise = require('rsvp').Promise;
 var Filter = require('../../');
 
-module.exports = Rot13Async;
 
-function Rot13Async(inputTree, options) {
-  if (!this) {
-    return new Rot13Async(inputTree, options);
+class Rot13Async extends Filter {
+  constructor(inputTree, options) {
+    super(inputTree, options);
   }
-  Filter.call(this, inputTree, options);
+
+  processString(content) {
+    return new Promise(function(resolve) {
+      var result = content.replace(/[a-zA-Z]/g, function(c){
+        return String.fromCharCode((c <= 'Z' ? 90 : 122) >= (c = c.charCodeAt(0) + 13) ? c : c - 26);
+      });
+      setTimeout(function() {
+        resolve(result);
+      }, 50);
+    });
+  }
 }
 
-inherits(Rot13Async, Filter);
-
-Rot13Async.prototype.processString = function(content) {
-  return new Promise(function(resolve) {
-    var result = content.replace(/[a-zA-Z]/g, function(c){
-      return String.fromCharCode((c <= 'Z' ? 90 : 122) >= (c = c.charCodeAt(0) + 13) ? c : c - 26);
-    });
-    setTimeout(function() {
-      resolve(result);
-    }, 100);
-  });
-};
+module.exports = Rot13Async;

--- a/test/test.js
+++ b/test/test.js
@@ -666,63 +666,62 @@ describe('Filter', function() {
     expect(file(results.directory + '/a/foo.js')).to.exist;
   }));
 
-  it('replaces stale entries', co.wrap(function* () {
+  describe('stale entries', function() {
     let fileForChange = path.join(fixturePath('a'), 'dir', 'a', 'README.md');
-
-    let builder = makeBuilder(ReplaceFilter, fixturePath('a'), awk => awk);
-
-    let results = yield builder('dir', {
-      glob: '**/*.md',
-      search: 'dogs',
-      replace: 'cats'
+    afterEach(function() {
+      write(fileForChange, 'Nicest cats in need of homes');
     });
 
-    expect(file(fileForChange)).to.exist;
+    it('replaces stale entries', co.wrap(function* () {
+      let builder = makeBuilder(ReplaceFilter, fixturePath('a'), awk => awk);
 
-    write(fileForChange, 'such changes');
+      let results = yield builder('dir', {
+        glob: '**/*.md',
+        search: 'dogs',
+        replace: 'cats'
+      });
 
-    expect(file(fileForChange)).to.exist;
+      expect(file(fileForChange)).to.exist;
 
-    results = yield results.builder();
+      write(fileForChange, 'such changes');
 
-    expect(file(fileForChange)).to.exist;
+      expect(file(fileForChange)).to.exist;
 
-    write(fileForChange, 'such changes');
+      results = yield results.builder();
 
-    expect(file(fileForChange)).to.exist;
+      expect(file(fileForChange)).to.exist;
 
-    write(fileForChange, 'Nicest cats in need of homes');
-  }));
+      write(fileForChange, 'such changes');
 
-  it('replaces stale entries - async', co.wrap(function* () {
-    let fileForChange = path.join(fixturePath('a'), 'dir', 'a', 'README.md');
+      expect(file(fileForChange)).to.exist;
+    }));
 
-    let subject = new ReplaceAsyncFilter(fixturePath('a'), {
-      glob: '**/*.md',
-      search: 'dogs',
-      replace: 'cats',
-      async: true,
-    });
-    let output = createBuilder(subject);
+    it('replaces stale entries - async', co.wrap(function* () {
+      let subject = new ReplaceAsyncFilter(fixturePath('a'), {
+        glob: '**/*.md',
+        search: 'cats',
+        replace: 'dogs',
+        async: true,
+      });
+      let output = createBuilder(subject);
 
-    yield output.build();
+      yield output.build();
 
-    expect(file(fileForChange)).to.exist;
+      expect(file(output.builder.outputPath + '/dir/a/README.md')).to.equal('Nicest dogs in need of homes');
 
-    write(fileForChange, 'such changes');
+      expect(file(fileForChange)).to.exist;
 
-    expect(file(fileForChange)).to.exist;
+      write(fileForChange, 'such changes');
 
-    yield output.build();
+      expect(file(fileForChange)).to.exist;
 
-    expect(file(fileForChange)).to.exist;
+      yield output.build();
 
-    write(fileForChange, 'such changes');
+      expect(file(output.builder.outputPath + '/dir/a/README.md')).to.equal('such changes');
+    }));
 
-    expect(file(fileForChange)).to.exist;
 
-    write(fileForChange, 'Nicest cats in need of homes');
-  }));
+  });
 
   it('does not overwrite core options if they are not present', function() {
     function F(inputTree, options) {

--- a/test/test.js
+++ b/test/test.js
@@ -216,7 +216,7 @@ describe('Filter', function() {
 
       beforeEach(co.wrap(function* () {
         input = yield createTempDir();
-        subject = new Plugin(input.path(), { async:true });
+        subject = new Plugin(input.path());
         output = createBuilder(subject);
       }));
 
@@ -540,23 +540,17 @@ describe('Filter', function() {
   }));
 
   it('targetExtension work for multiple extensions - async', co.wrap(function* () {
-    let builder = makeBuilder(Rot13AsyncFilter, fixturePath('a'), awk => {
-      sinon.spy(awk, 'processString');
-      return awk;
-    });
-
-    let results = yield builder('dir', {
+    let subject = new Rot13AsyncFilter(fixturePath('a'), {
       targetExtension: 'foo',
-      extensions: ['js','md'],
+      extensions: ['js', 'md'],
       async: true,
     });
+    let output = createBuilder(subject);
 
-    let awk = results.subject;
+    yield output.build();
 
-    expect(file(results.directory + '/a/README.foo')).to.equal('Avprfg pngf va arrq bs ubzrf');
-    expect(file(results.directory + '/a/foo.foo')).to.equal('Avprfg qbtf va arrq bs ubzrf');
-
-    expect(awk.processString.callCount).to.equal(3);
+    expect(output.read().dir['a']['README.foo']).to.equal('Avprfg pngf va arrq bs ubzrf');
+    expect(output.read().dir['a']['foo.foo']).to.equal('Avprfg qbtf va arrq bs ubzrf');
   }));
 
   it('handles directories that older versions of walkSync do not sort lexicographically', co.wrap(function* () {
@@ -707,14 +701,15 @@ describe('Filter', function() {
   it('replaces stale entries - async', co.wrap(function* () {
     let fileForChange = path.join(fixturePath('a'), 'dir', 'a', 'README.md');
 
-    let builder = makeBuilder(ReplaceAsyncFilter, fixturePath('a'), awk => awk);
-
-    let results = yield builder('dir', {
+    let subject = new ReplaceAsyncFilter(fixturePath('a'), {
       glob: '**/*.md',
       search: 'dogs',
       replace: 'cats',
       async: true,
     });
+    let output = createBuilder(subject);
+
+    yield output.build();
 
     expect(file(fileForChange)).to.exist;
 
@@ -722,7 +717,7 @@ describe('Filter', function() {
 
     expect(file(fileForChange)).to.exist;
 
-    results = yield results.builder();
+    yield output.build();
 
     expect(file(fileForChange)).to.exist;
 

--- a/test/test.js
+++ b/test/test.js
@@ -288,12 +288,14 @@ describe('Filter', function() {
       }
 
       beforeEach(co.wrap(function* () {
+        process.env.JOBS = '4';
         input = yield createTempDir();
         subject = new Plugin(input.path(), { async:true });
         output = createBuilder(subject);
       }));
 
       afterEach(co.wrap(function* () {
+        delete process.env.JOBS;
         yield input.dispose();
         yield output.dispose();
       }));

--- a/test/test.js
+++ b/test/test.js
@@ -316,7 +316,7 @@ describe('Filter', function() {
           expect(error.message).to.contain('file failed for some reason', 'error message text should match');
         }
         expect(didFail).to.eql(true, 'build should fail');
-        expect(output.read(), 'to be empty').to.deep.equal({
+        expect(output.read(), 'should write the files that did not fail').to.deep.equal({
           'index1.js': 'console.log("hi")',
           'index3.js': 'console.log("hi")',
         });
@@ -1037,7 +1037,8 @@ describe('throttling', function() {
   }));
 
   afterEach(co.wrap(function* () {
-    expect(output.read(), 'to be empty').to.deep.equal({
+    delete process.env.JOBS;
+    expect(output.read(), 'all files should be written').to.deep.equal({
       'index0.js': 'console.log("hi")',
       'index1.js': 'console.log("hi")',
       'index2.js': 'console.log("hi")',

--- a/test/test.js
+++ b/test/test.js
@@ -268,12 +268,14 @@ describe('Filter', function() {
           let shouldFail = this.shouldFail;
           this.shouldFail = !this.shouldFail;
 
-          return new Promise((resolve) => {
-            if (shouldFail) {
-              throw new Error('file failed to build');
-            }
+          return new Promise((resolve, reject) => {
             setTimeout(() => {
-              resolve(content);
+              if (shouldFail) {
+                reject('file failed for some reason');
+              }
+              else {
+                resolve(content);
+              }
             }, 50);
           });
         }
@@ -303,9 +305,9 @@ describe('Filter', function() {
           yield output.build();
         } catch(error) {
           didFail = true;
-          expect(error.message).to.contain('file failed to build');
+          expect(error.message).to.contain('file failed for some reason', 'error message text should match');
         }
-        expect(didFail).to.eql(true);
+        expect(didFail).to.eql(true, 'build should fail');
         expect(output.read(), 'to be empty').to.deep.equal({
           'index1.js': 'console.log("hi")',
           'index3.js': 'console.log("hi")',

--- a/test/test.js
+++ b/test/test.js
@@ -976,4 +976,21 @@ describe('Filter', function() {
         'Nicest dogs in need of homes')).to.eql(false);
     }));
   });
+
+  describe('concurrency', function() {
+    afterEach(function() {
+      delete process.env.JOBS;
+    });
+
+    it('sets concurrency automatically using detected cpus', function() {
+      let filter = MyFilter('.', {});
+      expect(filter.concurrency).to.equal(os.cpus().length);
+    });
+
+    it('sets concurrency using environment variable', function() {
+      process.env.JOBS = '12';
+      let filter = MyFilter('.', {});
+      expect(filter.concurrency).to.equal(12);
+    });
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -257,31 +257,27 @@ describe('Filter', function() {
       let output;
       let subject;
 
-      function Plugin(inputNode, options) {
-        if (!this) {
-          return new Plugin(inputNode, options);
+      class Plugin extends Filter {
+        constructor(inputTree, options) {
+          super(inputTree, options);
+          this.shouldFail = true;
         }
 
-        this.shouldFail = true;
-        Filter.call(this, inputNode, options);
+        processString(content) {
+          // every other file fails to build
+          let shouldFail = this.shouldFail;
+          this.shouldFail = !this.shouldFail;
+
+          return new Promise((resolve) => {
+            if (shouldFail) {
+              throw new Error('file failed to build');
+            }
+            setTimeout(() => {
+              resolve(content);
+            }, 50);
+          });
+        }
       }
-
-      inherits(Plugin, Filter);
-
-      Plugin.prototype.processString = function(content) {
-        // every other file fails to build
-        let shouldFail = this.shouldFail;
-        this.shouldFail = !this.shouldFail;
-
-        return new Promise(function(resolve) {
-          if (shouldFail) {
-            throw new Error('file failed to build');
-          }
-          setTimeout(function() {
-            resolve(content);
-          }, 50);
-        });
-      };
 
       beforeEach(co.wrap(function* () {
         input = yield createTempDir();

--- a/test/test.js
+++ b/test/test.js
@@ -989,15 +989,34 @@ describe('Filter', function() {
       delete process.env.JOBS;
     });
 
-    it('sets concurrency automatically using detected cpus', function() {
-      let filter = MyFilter('.', {});
-      expect(filter.concurrency).to.equal(os.cpus().length);
-    });
-
     it('sets concurrency using environment variable', function() {
       process.env.JOBS = '12';
       let filter = MyFilter('.', {});
       expect(filter.concurrency).to.equal(12);
+    });
+
+    it('sets concurrency using options.concurrency', function() {
+      process.env.JOBS = '12';
+      let filter = MyFilter('.', { concurrency: 15 });
+      expect(filter.concurrency).to.equal(15);
+    });
+
+    describe('CPU detection', function() {
+      afterEach(function() {
+        os.cpus.restore();
+      });
+
+      it('should set to detected CPUs - 1', function() {
+        sinon.stub(os, 'cpus').callsFake(() => ['cpu0', 'cpu1', 'cpu2']);
+        let filter = MyFilter('.', {});
+        expect(filter.concurrency).to.equal(2);
+      });
+
+      it('should have a min of 1', function() {
+        sinon.stub(os, 'cpus').callsFake(() => []);
+        let filter = MyFilter('.', {});
+        expect(filter.concurrency).to.equal(1);
+      });
     });
   });
 });


### PR DESCRIPTION
Currently all create and change operations are forced to happen sequentially. This change allows those operations to complete asynchronously, so that the files can be processed in parallel.

This gives a small speedup (~2-5%), and is the first step to improving the throughput of `broccoli-babel-transpiler`. This may also be useful for other plugins based on this filter.