### PR TITLE
fix: handle non-existent paths in isDirectory()

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,7 +267,11 @@ Filter.prototype.isDirectory = function(relativePath, entry) {
   var srcDir = this.inputPaths[0];
   var path = srcDir + '/' + relativePath;
 
-  return (entry || fs.lstatSync(path)).isDirectory();
+  try {
+    return (entry || fs.lstatSync(path)).isDirectory();
+  } catch (e) {
+    return false;
+  }
 };
 
 Filter.prototype.getDestFilePath = function(relativePath, entry) {


### PR DESCRIPTION
Before this change, moving or deleting files would cause an exception with a stack trace like:

```
The Broccoli Plugin: [SimpleConcatConcat] failed with:
Error: ENOENT: no such file or directory, lstat '/Users/lenny/Desktop/ember-css/host-app/tmp/broccoli_persistent_filtereslint_validation_filter-input_base_path-K2n3dQOH.tmp/integration/components/x-button-test.js'
    at Error (native)
    at Object.fs.lstatSync (fs.js:994:11)
    at EslintValidationFilter.Filter.isDirectory (/Users/lenny/Desktop/ember-css/host-app/node_modules/broccoli-persistent-filter/index.js:270:23)
    at EslintValidationFilter.Filter.getDestFilePath (/Users/lenny/Desktop/ember-css/host-app/node_modules/broccoli-persistent-filter/index.js:275:12)
    at EslintValidationFilter.getDestFilePath (/Users/lenny/Desktop/ember-css/host-app/node_modules/broccoli-lint-eslint/lib/index.js:134:55)
    at /Users/lenny/Desktop/ember-css/host-app/node_modules/broccoli-persistent-filter/index.js:154:52
    at /Users/lenny/Desktop/ember-css/host-app/node_modules/promise-map-series/index.js:11:14
    at tryCatch (/Users/lenny/Desktop/ember-css/host-app/node_modules/rsvp/dist/rsvp.js:525:12)
    at invokeCallback (/Users/lenny/Desktop/ember-css/host-app/node_modules/rsvp/dist/rsvp.js:538:13)
    at /Users/lenny/Desktop/ember-css/host-app/node_modules/rsvp/dist/rsvp.js:606:14

The broccoli plugin was instantiated at:
    at Concat.Plugin (/Users/lenny/Desktop/ember-css/host-app/node_modules/broccoli-plugin/index.js:7:31)
    at new Concat (/Users/lenny/Desktop/ember-css/host-app/node_modules/broccoli-concat/concat.js:38:10)
    at module.exports (/Users/lenny/Desktop/ember-css/host-app/node_modules/broccoli-concat/index.js:26:10)
    at Function.EslintValidationFilter.create (/Users/lenny/Desktop/ember-css/host-app/node_modules/broccoli-lint-eslint/lib/index.js:228:10)
    at Class.lintTree (/Users/lenny/Desktop/ember-css/host-app/node_modules/ember-cli-eslint/index.js:44:19)
    at addons.reduce (/Users/lenny/Desktop/ember-css/host-app/node_modules/ember-cli/lib/utilities/lint-addons-by-type.js:6:23)
    at Array.reduce (native)
    at lintAddonsByType (/Users/lenny/Desktop/ember-css/host-app/node_modules/ember-cli/lib/utilities/lint-addons-by-type.js:4:17)
    at EmberApp.addonLintTree (/Users/lenny/Desktop/ember-css/host-app/node_modules/ember-cli/lib/broccoli/ember-app.js:712:18)
    at EmberApp.lintTestTrees (/Users/lenny/Desktop/ember-css/host-app/node_modules/ember-cli/lib/broccoli/ember-app.js:1349:28)
```

This is easy to reproduce by running `ember serve`, then running `ember generate component x-button` followed by `ember destroy component x-button`.