### PR TITLE
Revert "Merge pull request #132 from stefanpenner/greenkeeper/sinon-4.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "minimatch": "^3.0.2",
     "mocha": "^3.0.0",
     "mocha-jshint": "^2.3.1",
-    "sinon": "^4.0.1",
+    "sinon": "^2.1.0",
     "sinon-chai": "^2.8.0"
   }
 }


### PR DESCRIPTION
This reverts commit 73ab1f48c5403b774314e807aba5b4651331bc83, reversing
changes made to 05299ee070c83fed949b3fffaa19cc4170620cb2.

sinon v4.0.1 includes a version of supports-color which uses `const`, which node v0.12 does not support. This ensures we're using a version of sinon that works with node v0.12.