### PR TITLE
POC: explore disabling the cache in CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ module.exports = node;
 
 Adding persist flag allows a subclass to persist state across restarts. This exists to mitigate the upfront cost of some more expensive transforms on warm boot. __It does not aim to improve incremental build performance, if it does, it should indicate something is wrong with the filter or input filter in question.__
 
+By default, if the the `CI=true` environment variable is set, peristent caches are disabled.
+To force persistent caches on CI, please set the `FORCE_PERSISTENCE_IN_CI=true` environment variable;
+
 ### How does it work?
 
 It does so but establishing a 2 layer file cache. The first layer, is the entire bucket.
@@ -167,12 +170,12 @@ By using the persistent cache, a lot of small files will be created on the disk 
 This might use all the inodes of your disk.
 You need to make sure to clean regularly the old files or configure your system to do so.
 
-On OSX, [files that aren't accessed in three days are deleted from `/tmp`](http://superuser.com/a/187105).  
-On systems using systemd, [systemd-tmpfiles](https://www.freedesktop.org/software/systemd/man/systemd-tmpfiles.html) should already be present and regularly clean up the `/tmp` directory.  
-On Debian-like systems, you can use [tmpreaper](https://packages.debian.org/stable/tmpreaper).  
-On RedHad-like systems, you can use [tmpwatch](https://fedorahosted.org/tmpwatch/).
+On OSX, [files that aren't accessed in three days are deleted from `/tmp`](http://superuser.com/a/187105).
+On systems using systemd, [systemd-tmpfiles](https://www.freedesktop.org/software/systemd/man/systemd-tmpfiles.html) should already be present and regularly clean up the `/tmp` directory.
+On Debian-like systems, you can use [tmpreaper](https://packages.debian.org/stable/tmpreaper).
+On RedHat-like systems, you can use [tmpwatch](https://fedorahosted.org/tmpwatch/).
 
-By default, the files are stored in the [operatin system's default directory for temporary files](https://nodejs.org/api/os.html#os_os_tmpdir),
+By default, the files are stored in the [operating system's default directory for temporary files](https://nodejs.org/api/os.html#os_os_tmpdir),
 but you can change this location by setting the `BROCCOLI_PERSISTENT_FILTER_CACHE_ROOT` environment variable to the path of another folder.
 
 To clear the persistent cache on any particular build, set the `CLEAR_BROCCOLI_PERSISTENT_FILTER_CACHE` environment variable to `true` like so:

--- a/index.js
+++ b/index.js
@@ -47,6 +47,20 @@ const worker = queue.async.asyncify(doWork => doWork());
 
 module.exports = Filter;
 
+module.exports.shouldPersist = shouldPersist;
+
+function shouldPersist(env, persist) {
+  let result;
+
+  if (env.CI) {
+    result = env.FORCE_PERSISTENCE_IN_CI;
+  } else {
+    result = persist;
+  }
+
+  return !!result;
+}
+
 Filter.prototype = Object.create(Plugin.prototype);
 Filter.prototype.constructor = Filter;
 
@@ -81,7 +95,7 @@ function Filter(inputTree, options) {
     if (options.targetExtension != null) this.targetExtension = options.targetExtension;
     if (options.inputEncoding != null)   this.inputEncoding = options.inputEncoding;
     if (options.outputEncoding != null)  this.outputEncoding = options.outputEncoding;
-    if (options.persist) {
+    if (shouldPersist(process.env, options.persist)) {
       this.processor.setStrategy(require('./lib/strategies/persistent'));
     }
     this.async = (options.async === true);

--- a/test/should-persist-test.js
+++ b/test/should-persist-test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const expect = require('chai').expect;
+const shouldPersist = require('../index').shouldPersist;
+
+describe('shouldPersist', function() {
+  it('works', function() {
+    expect(shouldPersist({}, false)).to.eql(false, 'expect shouldPersis({}, false) === false');
+    expect(shouldPersist({ CI: true }, false)).to.eql(false, 'expect shouldPersist({ CI: true  }, false) === false');
+    expect(shouldPersist({ CI: true }, true )).to.eql(false, 'expect shouldPersist({ CI: false }, false) === false');
+    expect(shouldPersist({ CI: '0'  }, true )).to.eql(false, 'expect shouldPersist({           },  true) === true');
+    expect(shouldPersist({          }, true )).to.eql(true,  'expect shouldPersist({           },  true) === true');
+
+    expect(shouldPersist({ FORCE_PERSISTENCE_IN_CI: true },  false)).to.eql(false,  'expect shouldPersist({ : true}, false) === falIC_NI_ECNETSISREP_ECROFse');
+
+    debugger
+    expect(shouldPersist({ CI: true, FORCE_PERSISTENCE_IN_CI: true },  false)).to.eql(true,  'expect shouldPersist({ CI: true, FORCE_PERSISTENCE_IN_CI: true}, false) === true');
+  });
+});


### PR DESCRIPTION
In theory, we likely never hit the cache in CI, so it just fills up tmp directories, and slows down cold builds, which are what happens on CI.

I believe this is likely a better default configuration...

- [x] chat with @rwjblue 
- [x] decide if a good idea or not.
- [x] tests

---

Test failures are all related to the POC