### PR TITLE
Normalize all paths used in dependency tracking.

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -133,12 +133,13 @@ module.exports = class Dependencies {
    *   containing the file that depends on them.
    */
   setDependencies(filePath, dependencies) {
+    filePath = path.normalize(filePath);
     if (this.sealed) {
       throw new Error("Cannot set dependencies when sealed");
     }
     /** @type {Array<string>} */
     let absoluteDeps = [];
-    let fileDir = path.dirname(path.normalize(filePath));
+    let fileDir = path.dirname(filePath);
     for (let i = 0; i < dependencies.length; i++) {
       let depPath = path.normalize(dependencies[i]);
       if (!path.isAbsolute(depPath)) {

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -219,6 +219,7 @@ module.exports = class Dependencies {
       for (let operation of patch) {
         let depPath = path.join(fsRoot, operation[1]);
         let dependents = this.dependentsMap.get(depPath);
+        if (!dependents) { continue; }
         for (let dep of dependents) {
           invalidated.add(dep);
         }

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -26,7 +26,7 @@ module.exports = class Dependencies {
      * paths are resolved against this directory.
      * @type {string}
      */
-    this.rootDir = rootDir;
+    this.rootDir = path.normalize(rootDir);
     /**
      * Tracks dependencies on a per file basis.
      * The key is a relative path, values are absolute paths.
@@ -138,9 +138,9 @@ module.exports = class Dependencies {
     }
     /** @type {Array<string>} */
     let absoluteDeps = [];
-    let fileDir = path.dirname(filePath);
+    let fileDir = path.dirname(path.normalize(filePath));
     for (let i = 0; i < dependencies.length; i++) {
-      let depPath = dependencies[i];
+      let depPath = path.normalize(dependencies[i]);
       if (!path.isAbsolute(depPath)) {
         depPath = path.resolve(this.rootDir, fileDir, depPath);
       }
@@ -160,6 +160,7 @@ module.exports = class Dependencies {
    * @returns {Dependencies}
    */
   copyWithout(files) {
+    files = files.map(f => path.normalize(f));
     let newDeps = new Dependencies(this.rootDir);
     for (let file of this.dependencyMap.keys()) {
       if (!files.includes(file)) {
@@ -288,7 +289,7 @@ module.exports = class Dependencies {
    */
   static deserialize(dependencyData, newRootDir) {
     let oldRootDir = dependencyData.rootDir;
-    newRootDir = newRootDir || oldRootDir;
+    newRootDir = path.normalize(newRootDir || oldRootDir);
     let dependencies = new Dependencies(newRootDir);
     let files = Object.keys(dependencyData.dependencies);
     for (let file of files) {

--- a/test/dependencies-test.js
+++ b/test/dependencies-test.js
@@ -17,11 +17,10 @@ function pathFor(root, filePath) {
     filePath = root;
     root = undefined;
   }
-  filePath = filePath.split("/").join(path.sep);
   if (root) {
-    return path.normalize(path.resolve(root, filePath));
+    return path.resolve(root, filePath);
   } else {
-    return filePath;
+    return path.normalize(filePath);
   }
 }
 
@@ -65,6 +64,18 @@ describe('Dependency Invalidation', function() {
     dependencies.setDependencies(pathFor('subdir/subdirFile1.txt'), [
       pathFor(DEP_FIXTURE_DIR, 'subdir/subdirFile2.txt'),
       pathFor(EXT_DEP_FIXTURE_DIR, 'dep-1.txt')
+    ]);
+    assert.deepEqual(dependencies.dependencyMap.get(pathFor('subdir/subdirFile1.txt')), [
+      pathFor(DEP_FIXTURE_DIR, 'subdir/subdirFile2.txt'),
+      pathFor(EXT_DEP_FIXTURE_DIR, 'dep-1.txt')
+    ]);
+  });
+
+  it('normalizes paths', function() {
+    let dependencies = new Dependencies(path.join(__dirname, 'fixtures', 'something', '..', 'dependencies')); // always uses path.sep and contains a parent directory.
+    dependencies.setDependencies('othersubdir/../subdir/subdirFile1.txt', [ // always passes unix paths and contains a parent directory.
+      path.join(DEP_FIXTURE_DIR, 'thirdSubdir/../subdir/subdirFile2.txt'), // mixes windows and unix paths and has a parent directory.
+      path.join(EXT_DEP_FIXTURE_DIR, 'dep-1.txt')
     ]);
     assert.deepEqual(dependencies.dependencyMap.get(pathFor('subdir/subdirFile1.txt')), [
       pathFor(DEP_FIXTURE_DIR, 'subdir/subdirFile2.txt'),


### PR DESCRIPTION
This makes the library work with code that expects a generalized behavior similar to node's path and fs libraries where `/` is converted into `\` automatically. But it also will prevent string comparison failures for different representations of the same path, so it seems like a good fix all around.